### PR TITLE
Update URLs in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ currently you would need to use the compiler hint of `@deno-types`. For example
 to import React:
 
 ```typescript
-// @deno-types="https://deno.land/std/types/react/@16.13.1/react.d.ts"
+// @deno-types="https://deno.land/x/types/react/v16.13.1/react.d.ts"
 import React from "https://cdn.pika.dev/@pika/react@v16.13.1";
 ```
 
 or
 
 ```typescript
-// @deno-types="https://deno.land/std/types/react/@16.13.1/react.d.ts"
+// @deno-types="https://deno.land/x/types/react/v16.13.1/react.d.ts"
 import React from "https://dev.jspm.io/react@16.13.1";
 ```
 


### PR DESCRIPTION
This PR updates the URL of the React type definitions in the documentation, to reflect their new location at `deno.land/x/types`.

The types worked for me, but only after I figured out the correct URL to load them.