### PR TITLE
Update jspm example to use latest jspm.dev CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ or
 
 ```typescript
 // @deno-types="https://denopkg.com/soremwar/deno_types/react/v16.13.1/react.d.ts"
-import React from "https://dev.jspm.io/react@16.13.1";
+import React from "https://jspm.dev/react@16.13.1";
 ```
 
 #### Notes:


### PR DESCRIPTION
The dev.jspm.io CDN has been replaced by jspm.dev, see https://jspm.org/ for more info.

This updates the example in the README here to reflect that. If you know of other projects still using the older CDN URL it would help to know to update those as well.

If there are any upgrade issues or differences I'd be happy to take a look further.